### PR TITLE
add GeoCODES validation rulesets

### DIFF
--- a/shapeGraphs/GeoCodesv1RecommendedShapes.ttl
+++ b/shapeGraphs/GeoCodesv1RecommendedShapes.ttl
@@ -1,0 +1,310 @@
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ecgeo: <https://geocodes.earthcube.org/validation/0.1/shacl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix soso: <http://science-on-schema.org/1.2.3/validation/shacl#> .
+@prefix datacite: <http://purl.org/spar/datacite/> .
+@prefix time: <http://www.w3.org/2006/time#>.
+
+
+# copy from https://github.com/gleanerio/notebooks/blob/master/notebooks/validation/shapes/geocodes_v1.ttl
+# by Doug Fils to start work on GeoCODES schacl validation
+# SMR 2022-07-25
+# lean heavily on Doug Fils documentation for Ocean Info Hub and 
+# ESIP Fed science-on-schema.org
+# change namespace from oihval: to ecgeo:
+
+		
+		
+ecgeo:GeoCODESDatasetRecommendedShape
+    a sh:NodeShape ;
+    sh:targetClass schema:Dataset ;
+    sh:message "GeoCODES validation suite recommended properties, for Datasets" ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;	
+    sh:property	
+		ecgeo:mainEntityProperty,
+        ecgeo:keywordsResourceProperty,
+		ecgeo:keywordsNoCommaProperty,
+        ecgeo:citationProperty,
+        ecgeo:subjectOfProperty,
+        ecgeo:otherIdentifierProperty,
+        ecgeo:responsiblePartyProperty,
+		ecgeo:spatialExtentProperty,
+		ecgeo:temporalExtentProperty,
+		ecgeo:variableMeasuredProperty,
+        ecgeo:datePublishedProperty
+.
+
+ecgeo:GeoCODESPersonShape
+    a sh:NodeShape ;
+    sh:targetClass schema:Person ;
+	sh:property ecgeo:affiliationProperty;
+    sh:property ecgeo:nameProperty ;
+	sh:message "A person must a name provided; affiliation to an organization and identifier are strongly recommended." 
+	.
+
+ecgeo:GeoCODESOrganizationShape
+    a sh:NodeShape ;
+    sh:targetClass schema:Organization ;
+    sh:property ecgeo:nameProperty;
+    sh:message "Organization must have a name at least 15 characters long; Make it useful for users!!" 
+.
+
+ecgeo:affiliationProperty
+# affiliation is always with an organization
+    a sh:PropertyShape ;
+    sh:path schema:affiliation ;
+    sh:class  schema:Organization  ;
+	sh:severity sh:Warning ;
+    sh:message "Optional: an affiliation must have object schema:Organization" 
+    .
+
+ecgeo:nameProperty
+# names must be a literal, at least 15 char long.
+    a sh:PropertyShape ;
+    sh:path schema:name;
+    sh:nodeKind sh:Literal ;
+	sh:minLength 10 ;
+	sh:severity sh:Warning ;
+    sh:message "a name must be provided, at least 10 char long." 
+    .
+	
+#start specific properties
+ecgeo:mainEntityProperty
+    a sh:PropertyShape ;
+    sh:path schema:mainEntity ;
+	sh:and (
+	   [sh:class schema:CreativeWork ] 
+	   [sh:path schema:url ;
+	      sh:hasValue "http://schema.org/Dataset" ]
+	);
+	sh:severity sh:Info ;
+    sh:message "schema:mainEntity property is optional for Datasets, but is required to enable editing with EC GeoCODES JSON forms."@en ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+
+ecgeo:keywordsResourceProperty
+    a sh:PropertyShape ;
+    sh:path schema:keywords ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:Literal ;
+    sh:severity sh:Warning ;
+    sh:message "A resource should include descriptive keywords as an array of strings" ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+	
+ecgeo:keywordsNoCommaProperty
+#should throw warning if there is a comma character in a keyword string. Not working... ?WHY?
+    a sh:PropertyShape ;
+    sh:path schema:keywords ;
+	#regex for a string without a comma
+	sh:pattern "^(?!.+,).+" ;
+#	sh:maxCount 0; 
+    sh:severity sh:Warning ;
+    sh:message "If there are multiple keywords, they should be in an array; an individual keyword MUST not contain a comma character" ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+	
+ecgeo:citationProperty
+    a sh:PropertyShape ;
+    sh:path schema:citation ;
+    sh:severity sh:Info ;
+    sh:message "schema:citation is not recommended for use in GeoCODES because of semantic ambiguity. If you want to provide a recommended citation for the resource described by the record, use dct:bibliographicCitation; if you want to cite related resources, use schema:isRelatedTo." ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+
+ecgeo:subjectOfProperty
+    a sh:PropertyShape ;
+    sh:path schema:subjectOf ;
+    sh:or (
+ 	[sh:class schema:DataDownload ;
+     		sh:property [sh:path schema:encodingFormat ;
+	   			sh:nodeKind sh:IRIOrLiteral ;
+    			        sh:minCount 1 ] ;
+  		sh:property [sh:path schema:contentUrl ;
+	  			sh:nodeKind sh:IRIOrLiteral;
+    			        sh:minCount 1] 
+ 		] 
+        [sh:class schema:CreativeWork ;
+            sh:property [sh:path schema:name;
+             	sh:nodeKind sh:Literal;
+                  sh:minCount 1;
+                  sh:message "a linked resource should have a name to label the link" ] ;
+             sh:property [sh:path schema:url;
+             	sh:nodeKind sh:Literal;
+                  sh:minCount 1;
+                  sh:message "a linked resource with subjectOf MUST have a url to get the resource"] 
+         ]
+     );
+    sh:severity sh:Info ;
+    sh:message "SubjectOf property can link to a more formal metadata record (per ESIP SOSO recommendations), or more generally link to other resources that are specifically based on the described data. For linked metadata, the value must be DataDownload with a contentURL to get the formal metadata record, and an encodingFormat property that identifies the metadata scheme. Linked resources have a CreativeWork value that must provide a name and url for the linked resource. " ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+	
+ecgeo:otherIdentifierProperty
+    a sh:PropertyShape ;
+    sh:path schema:sameAs ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:IRIOrLiteral ;
+    sh:severity sh:Info ;
+    sh:message "Optional: Provide other identifiers as an array of strings or URIs, recommended by ESIPfed SOSO" ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+	
+ecgeo:responsiblePartyProperty
+    a sh:PropertyShape ;
+    sh:path [sh:alternativePath ( schema:creator schema:editor schema:contributor  schema:publisher ) ]  ;
+    sh:or (  [  sh:class  schema:Person ]
+             [   sh:class  schema:Organization ] )  ;
+	sh:minCount 1;
+   	sh:message "Optional: Recommended practice is to identify at least one responsible party as the source authority for the dataset. Options include  creator, editor, contributor, or publisher. Each is either a schema:Person or schema:Organization and MUST have at least a name." ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    sh:severity sh:Info 
+    .
+	
+ecgeo:spatialExtentProperty
+    a sh:PropertyShape ;
+    sh:path schema:spatialCoverage;
+    sh:minCount 1 ;
+    sh:class schema:Place ;
+      sh:or (  [sh:path schema:geo ;
+                  sh:or (  [  sh:class  schema:GeoCoordinates ]
+                           [  sh:class  schema:GeoShape ] )  ;
+	              sh:minCount 1 ;
+	              sh:message "spatial location MUST be specified eitehr with GeoCoordinates lat/long pairs (for point location), or with GeoShape  Line, Box or Polygon." ;]
+               [sh:path schema:name;
+                  sh:nodeKind sh:Literal;
+                  sh:minCount 1 ]
+      );
+    sh:severity sh:Info ;
+    sh:message "Recommended: provide a spatial coverage description if applicable using schema:Place, either a place name,  point location(s) (GeoCoordinates), or GeoShape (bounding box, line profile location, or polygon)." ;
+    .
+ 
+ ecgeo:geoCoordinatesNode
+	a sh:NodeShape ;
+    sh:targetClass schema:GeoCoordinates ;
+	sh:property [ sh:path schema:latitude ;
+	#pyshacl seems to assume that decimal numbers are xsd:doubles...
+	# pyshacl doesn't seem to pay attention to min and max values
+			sh:or ( [sh:datatype xsd:double ]
+					[sh:datatype xsd:integer ] );
+			sh:minValue -90.0;
+			sh:maxValue 90.0;
+			sh:minCount 1 ] ;
+	sh:property [sh:path schema:longitude ;
+			sh:or ( [sh:datatype xsd:double ]
+					[sh:datatype xsd:integer ] );
+			sh:minValue -180.0;
+			sh:maxValue 180.0;
+			sh:minCount 1 ] ;
+	   sh:message "GeoCoodinates must include latitude between -90 and 90, and longitude between -180 and 180." ;
+	.
+
+  ecgeo:geoShapeNode
+	a sh:NodeShape ;
+    sh:targetClass schema:GeoShape ;
+	sh:property
+		[sh:path [sh:alternativePath ( schema:line schema:polygon schema:box) ];
+			sh:datatype xsd:string;
+			sh:minCount 1 ;
+            sh:message "geoshape must include a line, polygon or box geometry as a string of latitude longitude pairs"
+		]
+.
+
+ecgeo:temporalExtentProperty
+	a sh:PropertyShape ;
+	sh:path schema:temporalCoverage ;
+	sh:or (
+		[sh:class time:ProperInterval ; ] 
+		[sh:nodeKind sh:IRIOrLiteral ;]
+          );
+	sh:message "temporalCoverage problem; need either an ISO 8601 dateTime or a time:ProperInterval" ;
+	.
+	
+
+ecgeo:timeIntervalNode
+	a sh:NodeShape ;
+    sh:targetClass time:ProperInterval ;
+	sh:property
+		[ sh:path time:hasBeginning ;
+		sh:class time:Instant ;
+		sh:minCount 1;
+		sh:message "A time interval must have a beginning "
+		] ;
+	sh:property
+		[ sh:path time:hasEnd ;
+		sh:class time:Instant ;
+		sh:minCount 1;
+		sh:message "A time interval must have an end "
+		]
+	.
+
+ecgeo:timeInstantNode
+	a sh:NodeShape; 
+	sh:targetClass time:Instant ;
+	sh:property 
+		[sh:path [sh:alternativePath ( time:inXSDDateTimeStamp time:inTimePosition) ] ;
+		sh:nodeKind sh:BlankNodeOrLiteral;
+		sh:minCount 1 ;
+		sh:maxCount 1 ;
+        sh:message "a time instant must be specified by only one of xsd DateTime or a TimePosition"
+		] ;
+	sh:property
+		[sh:path time:inXSDDateTimeStamp ;
+          sh:nodeKind  sh:Literal   ] ;
+	sh:property
+		[sh:path time:inTimePosition ;
+           sh:class time:TimePosition ;
+        	sh:message "inTimePosition must have a TimePosition object as a value"] 
+	.
+	
+ecgeo:timePositionNode
+	a sh:NodeShape; 
+	sh:targetClass time:TimePosition ;
+	sh:property 	
+		[
+		sh:path time:hasTRS ;
+		sh:nodeKind sh:IRIOrLiteral;
+		sh:message "include identifier for the temporal reference system as a string or @id with a URI value"
+		];	
+	sh:property
+		[
+		sh:path time:numericPosition;
+		sh:or ( [sh:datatype xsd:integer]
+               [sh:datatype xsd:double] ) ;
+		sh:message "time position MUST have a numeric value"
+		]
+	.
+	
+	
+ecgeo:variableMeasuredProperty
+    a sh:PropertyShape ;
+    sh:path schema:variableMeasured;
+    sh:class schema:PropertyValue ;
+		sh:property 
+		[sh:path schema:name ;
+		sh:datatype xsd:string ;
+		sh:minCount 1;
+		sh:message "the name of the variable as it is labeled in the dataset must be specified"
+		];
+	sh:property 
+		[sh:path schema:description ;
+		sh:datatype xsd:string ;
+		sh:minCount 1;
+		sh:severity sh:Info;
+		sh:message "including a description of the variable is strongly recommended"
+		];
+	sh:minCount 0;
+    sh:message "if variable measured is specified, at least one PropertyValue description must be included" 
+    .
+	
+ecgeo:datePublishedProperty
+    a sh:PropertyShape ;
+    sh:path schema:datePublished;
+    sh:nodeKind sh:Literal ;
+	sh:severity sh:Info ;
+    sh:message "Please provide a publication or release date." 
+    .

--- a/shapeGraphs/GeoCodesv1Shapes.ttl
+++ b/shapeGraphs/GeoCodesv1Shapes.ttl
@@ -1,0 +1,191 @@
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix ecgeo: <https://geocodes.earthcube.org/validation/0.1/shacl#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix soso: <http://science-on-schema.org/1.2.3/validation/shacl#> .
+@prefix datacite: <http://purl.org/spar/datacite/> .
+
+# copy from https://github.com/gleanerio/notebooks/blob/master/notebooks/validation/shapes/geocodes_v1.ttl
+# by Doug Fils to start work on GeoCODES schacl validation
+# SMR 2022-07-25
+# lean heavily on Doug Fils documentation for Ocean Info Hub and 
+# ESIP Fed science-on-schema.org 
+# change namespace from oihval: to ecgeo:
+	
+ecgeo:DatasetNS2Shape
+    a sh:NodeShape ;
+# check for wrong http protocol (https)
+	sh:description "https://github.com/ESIPFed/science-on-schema.org/blob/develop/guides/GETTING-STARTED.md#specifying-the-context" ;
+	sh:targetClass <https://schema.org/Dataset>;
+	sh:property [
+		sh:path [sh:inversePath rdf:type ];
+		sh:minCount 1;
+        sh:message "Expecting SO namespace of <http://schema.org/> not <https://schema.org/>"@en ;
+	]	;
+	sh:severity sh:Warning
+	.
+
+	
+ecgeo:DatasetNS1Shape
+    a sh:NodeShape ;
+# check for missing backslash on namespace URI
+	sh:description "https://github.com/ESIPFed/science-on-schema.org/blob/develop/guides/GETTING-STARTED.md#specifying-the-context" ;
+	sh:targetClass <http://schema.orgDataset>;
+	sh:property [
+		sh:path [sh:inversePath rdf:type ];
+		sh:minCount 1;
+		sh:message "Expecting SO namespace of <http://schema.org/> not <http://schema.org> (add the terminal '/' character)"@en ;
+	]
+	.
+
+ecgeo:DatasetNS3Shape
+    a sh:NodeShape ;
+# check for wrong http protocol (https) and missing backslash on namespace URI
+	sh:description "https://github.com/ESIPFed/science-on-schema.org/blob/develop/guides/GETTING-STARTED.md#specifying-the-context" ;
+	sh:targetClass <https://schema.orgDataset>;
+	sh:property [
+		sh:path [sh:inversePath rdf:type ];
+		sh:minCount 1;
+		sh:message "Expecting SO namespace of <http://schema.org/> not <https://schema.org> (http, not https, and need terminal '/')"@en ;
+	]
+	.				  
+
+ecgeo:IDShape
+    a sh:NodeShape ;
+    sh:targetClass schema:Dataset ;
+    sh:message "Metadata record SHOULD have an identifier. Use the @id property, value is a string that is a URI identifying the metadata record (not the resource it describes--that goes in schema:identifier field)."@en ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf, see Metadata Identifier section. " ;
+    sh:nodeKind sh:IRIOrLiteral  ;
+	sh:severity sh:Warning
+    .
+	
+ecgeo:GeoCODESDatasetCommonShape
+    a sh:NodeShape ;
+    sh:targetClass schema:Dataset ;
+    sh:message "GeoCODES validation suite, mandatory properties for Datasets" ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf." ;
+    sh:property
+        ecgeo:datasetNameProperty,
+        ecgeo:descriptionProperty,
+        ecgeo:licenseResourceProperty,
+        ecgeo:identifierProperty,
+        ecgeo:identifierTypeProperty,
+		ecgeo:identifierPropertyValueProperties,
+		ecgeo:accessLinkProperty,
+		ecgeo:isAccessibleForFreeProperty
+	.
+		
+ecgeo:datasetNameProperty
+    a sh:PropertyShape ;
+    sh:path schema:name ;
+    sh:nodeKind sh:Literal ;
+	sh:minLength 15 ;
+    sh:message "Name is required; Dataset names must have at least 15 characters"@en ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+ecgeo:descriptionProperty
+    a sh:PropertyShape ;
+    sh:path schema:description;
+    sh:nodeKind sh:Literal ;
+    sh:minCount 1 ;
+	sh:minLength 50 ;
+	#description must be at least 50 characters
+    sh:message "Resource must have a description at least 50 characters long"@en ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+ecgeo:licenseResourceProperty
+    a sh:PropertyShape ;
+    sh:path schema:license ;
+   sh:minCount 1 ;
+    sh:or (
+		[sh:class schema:CreativeWork ;]
+		[sh:nodeKind sh:IRIOrLiteral ;]
+          );
+    sh:message "license items must be a string, URL or schema:CreativeWork"@en ;
+    sh:severity sh:Warning ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+ecgeo:identifierProperty
+    a sh:PropertyShape ;
+    sh:path schema:identifier;
+    sh:minCount 1 ;
+    sh:or (
+        [ sh:nodeKind sh:Literal ; ]
+        [ sh:class schema:URL ; ]
+        [ sh:class schema:PropertyValue ; ]
+    );
+    sh:message "Dataset identifier is required and must be a URL, Text or PropertyValue"@en ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+	sh:severity sh:Warning
+    .
+
+# display info message if identifier with type schema:PropertyValue is used
+ecgeo:identifierTypeProperty
+    a sh:PropertyShape ;
+    sh:path  schema:identifier ;
+	sh:not [
+        sh:class schema:PropertyValue;		
+#        sh:minCount 1;
+    ];
+    sh:severity sh:Info ;
+    sh:message "Although SOSO guidance allows PropertyValue to specify an identifier, GeoCODES recommends used of a plain literal or URI string. "@en ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+	
+ecgeo:identifierPropertyValueProperties
+    a sh:PropertyShape ;
+	sh:path schema:identifier  ;
+# only want rule to catch if there is a PropertyValue identifier, not if its a literal... HOW?
+	sh:or (
+		[ sh:nodeKind sh:Literal ; ]
+        [ sh:class schema:URL ; ]
+        [ sh:path schema:value;  sh:nodeKind sh:Literal ; ]
+        [ sh:path schema:url; sh:class schema:URL ; ] 
+	) ;
+#	sh:minCount 1;
+    sh:message "If identifier is specified with PropertyValue, then either a url or a value string with the identifier MUST be supplied"@en ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+
+ecgeo:accessLinkProperty
+    a sh:PropertyShape ;
+    sh:path [sh:alternativePath ( schema:url   (schema:distribution [sh:oneOrMorePath schema:accessUrl] ) 
+            (schema:distribution [sh:oneOrMorePath schema:contentUrl] )	) ] ;
+	sh:minCount 1 ;
+	sh:or (
+		[sh:nodeKind sh:Literal ;]
+		[sh:class schema:URL ;]
+		) ; 
+	sh:message "Some web location to access the resource or a representation of the resource must be provided. This can be a schema:url element on the dataset, a distribution/DataDownload/contentUrl or a distribution/DataDownload/url"@en ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+	
+ecgeo:DataDownloadNode
+    a sh:NodeShape ;
+	sh:targetClass schema:DataDownload ;
+	sh:property [
+		sh:path [sh:alternativePath ( schema:url  schema:contentUrl) ] ;
+		sh:minCount 1 ;
+		sh:or (
+			[sh:nodeKind sh:Literal ;]
+			[sh:class schema:URL ; ]
+			) ; 
+		sh:message "a distribution MUST provide either a contentUrl for direct data download or a url to access a landing page or order form."@en ;
+		] ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+	
+	
+ecgeo:isAccessibleForFreeProperty
+    a sh:PropertyShape ;
+    sh:path schema:isAccessibleForFree ;
+    sh:minCount 1 ;
+    sh:nodeKind sh:Literal ;
+    sh:severity sh:Warning ;
+    sh:message "Indicate if the dataset is accessible without monetary cost using the isAccessibleForFree property; value is True or False" ;
+    sh:description "https://github.com/earthcube/GeoCODES-Metadata/blob/main/docs/GeoCODES%20Dataset%20Metadata.pdf" ;
+    .
+	


### PR DESCRIPTION
two sets of SHACL rules,

-  GeoCodesv1Shapes.ttl to test for base content requirements for dataset metadata for EarthCube GeoCodes schema.org
- GeoCodesv1RecommendedShapes.ttl: test for recommended schema.org properties for dataset metadata for EarthCube GeoCODES harvest. 

